### PR TITLE
add continue on error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langchain-outline"
-version = "0.2.0"
+version = "0.3.0"
 description = "Langchain Document loader for Outline"
 authors = [
     {name = "Diego Tabares",email = "diego.tabares@10pines.com"},

--- a/src/langchain_outline/document_loaders/outline.py
+++ b/src/langchain_outline/document_loaders/outline.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from typing import Any, Callable, Dict, Iterable, Iterator, List, Tuple, Union
 
@@ -5,6 +6,8 @@ import requests
 from langchain_core.documents import Document
 
 from langchain_community.document_loaders.base import BaseLoader
+
+logger = logging.getLogger(__name__)
 
 class OutlineLoader(BaseLoader):
     """Load `Outline` documents.
@@ -36,6 +39,7 @@ class OutlineLoader(BaseLoader):
         outline_api_key: Union[str | None] = None,
         outline_collection_id_list: Union[List[str] | None] = None,
         page_size: int = 25,
+        continue_on_failure: bool = False,
     ):
         """Initialize with url, api_key and requested page size for API results
         pagination.
@@ -47,6 +51,8 @@ class OutlineLoader(BaseLoader):
         :param outline_collection_id_list: List of collection ids to be retrieved. If None all will be retrieved.
 
         :param page_size: How many outline documents should be retrieved per request
+
+        :param continue_on_failure: Whether to continue loading documents even if there is an error during fetching.
         """
 
         self.outline_base_url = outline_base_url or os.environ["OUTLINE_INSTANCE_URL"]
@@ -57,10 +63,11 @@ class OutlineLoader(BaseLoader):
         self.collection_info_endpoint = f"{self.outline_base_url}/api/collections.info"
         self.collection_ids = outline_collection_id_list
         self.page_size = page_size
+        self.continue_on_failure = continue_on_failure
         self.headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",
-            "Authorization": f"Bearer {outline_api_key}",
+            "Authorization": f"Bearer {self.outline_api_key}",
         }
 
     def lazy_load(self) -> Iterator[Document]:
@@ -68,17 +75,45 @@ class OutlineLoader(BaseLoader):
         Loads documents from Outline.
         """
         for collection in self._collections():
-            documents = self._fetch_documents(collection["id"])
-            for document in documents:
-                text = document["text"]
-                metadata = self._build_metadata(document, collection)
-                yield Document(page_content=text, metadata=metadata)
+            try:
+                documents = self._fetch_documents(collection["id"])
+                for document in documents:
+                    try:
+                        text = document["text"]
+                        metadata = self._build_metadata(document, collection)
+                        yield Document(page_content=text, metadata=metadata)
+                    except Exception as e:
+                        if self.continue_on_failure:
+                            logger.warning(
+                                f"Error processing document "
+                                f"'{document.get('title', document.get('id', 'unknown'))}': {e}"
+                            )
+                            continue
+                        raise
+            except Exception as e:
+                if self.continue_on_failure:
+                    logger.warning(
+                        f"Error fetching documents for collection "
+                        f"'{collection.get('name', collection['id'])}': {e}"
+                    )
+                    continue
+                raise
 
     def _build_metadata(self, document: Any, collection: Any) -> Dict:
-        document_group_permission_metadata = self._fetch_document_group_permission_metadata(document["id"])
         read_groups = []
-        for document_group_permission in document_group_permission_metadata:
-            read_groups.extend(document_group_permission["groups"])
+        try:
+            document_group_permission_metadata = self._fetch_document_group_permission_metadata(document["id"])
+            for document_group_permission in document_group_permission_metadata:
+                read_groups.extend(document_group_permission["groups"])
+        except Exception as e:
+            if self.continue_on_failure:
+                logger.warning(
+                    f"Could not fetch group permissions for document "
+                    f"'{document.get('title', document.get('id', 'unknown'))}': {e}"
+                )
+            else:
+                raise
+
         metadata = {"source": f"{self.outline_base_url}{document['url']}"}
         metadata["collection_permission"] = collection["permission"]
         metadata["collection_name"] = collection["name"]
@@ -146,14 +181,13 @@ class OutlineLoader(BaseLoader):
 
     def _extract_pagination_info(self, pagination_data: Dict) -> Tuple[int, int]:
         next_path = pagination_data.get("nextPath", "")
-        next_offset = 0
+        total = pagination_data.get("total", 0)
+        next_offset = total
         if next_path:
             try:
                 offset_str = next_path.split("offset=")[1].split("&")[0]
                 next_offset = int(offset_str)
             except (IndexError, ValueError):
-                next_offset = 0
-
-        total = pagination_data.get("total", 0)
+                next_offset = total
 
         return next_offset, total

--- a/src/langchain_outline/document_loaders/outline.py
+++ b/src/langchain_outline/document_loaders/outline.py
@@ -84,7 +84,7 @@ class OutlineLoader(BaseLoader):
                         yield Document(page_content=text, metadata=metadata)
                     except Exception as e:
                         if self.continue_on_failure:
-                            logger.warning(
+                            logger.error(
                                 f"Error processing document "
                                 f"'{document.get('title', document.get('id', 'unknown'))}': {e}"
                             )
@@ -92,7 +92,7 @@ class OutlineLoader(BaseLoader):
                         raise
             except Exception as e:
                 if self.continue_on_failure:
-                    logger.warning(
+                    logger.error(
                         f"Error fetching documents for collection "
                         f"'{collection.get('name', collection['id'])}': {e}"
                     )
@@ -107,7 +107,7 @@ class OutlineLoader(BaseLoader):
                 read_groups.extend(document_group_permission["groups"])
         except Exception as e:
             if self.continue_on_failure:
-                logger.warning(
+                logger.error(
                     f"Could not fetch group permissions for document "
                     f"'{document.get('title', document.get('id', 'unknown'))}': {e}"
                 )

--- a/tests/document_loaders/test_outline.py
+++ b/tests/document_loaders/test_outline.py
@@ -335,4 +335,98 @@ def test_fetch_no_documents_in_collection(
         
         documents = list(outline_loader.lazy_load()) 
 
-        assert len(documents) == 0
+@pytest.fixture
+def mock_response_collections_list_multiple_items() -> Dict:
+    return {
+        "data": [
+            {
+                "id": "col1",
+                "name": "Collection 1",
+                "description": "First collection",
+                "permission": "read",
+            },
+            {
+                "id": "col2",
+                "name": "Collection 2",
+                "description": "Second collection",
+                "permission": "read",
+            },
+        ],
+        "pagination": {"nextPath": None, "total": 2},
+    }
+
+def test_continue_on_failure_collection_error(
+    mock_response_collections_list_multiple_items: Dict,
+    mock_response_single_page: Dict,
+    mock_response_doc_group_memberships_for_doc1: Dict,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    loader = OutlineLoader(
+        outline_base_url="http://outline.test",
+        outline_api_key="test-api-key",
+        continue_on_failure=True
+    )
+    with requests_mock.Mocker() as m:
+        m.post("http://outline.test/api/collections.list", json=mock_response_collections_list_multiple_items)
+        # Fail for col1, succeed for col2
+        m.post("http://outline.test/api/documents.list", [
+            {"status_code": 500},
+            {"json": mock_response_single_page}
+        ])
+        m.post("http://outline.test/api/documents.group_memberships", json=mock_response_doc_group_memberships_for_doc1)
+
+        documents = list(loader.lazy_load())
+
+        assert len(documents) == 1
+        assert documents[0].page_content == "Test document 1"
+        assert "Error fetching documents for collection 'Collection 1'" in caplog.text
+
+def test_continue_on_failure_group_memberships_error(
+    mock_response_collections_list_single_item: Dict,
+    mock_response_single_page: Dict,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    loader = OutlineLoader(
+        outline_base_url="http://outline.test",
+        outline_api_key="test-api-key",
+        continue_on_failure=True
+    )
+    with requests_mock.Mocker() as m:
+        m.post("http://outline.test/api/collections.list", json=mock_response_collections_list_single_item)
+        m.post("http://outline.test/api/documents.list", json=mock_response_single_page)
+        m.post("http://outline.test/api/documents.group_memberships", status_code=403)
+
+        documents = list(loader.lazy_load())
+
+        assert len(documents) == 1
+        assert documents[0].metadata["read_groups"] == []
+        assert "Could not fetch group permissions for document 'Test 1'" in caplog.text
+
+def test_continue_on_failure_document_processing_error(
+    mock_response_collections_list_single_item: Dict,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    loader = OutlineLoader(
+        outline_base_url="http://outline.test",
+        outline_api_key="test-api-key",
+        continue_on_failure=True
+    )
+    # Document missing 'text' key will cause a KeyError in lazy_load
+    bad_document_response = {
+        "data": [
+            {"id": "bad_doc", "title": "Bad Doc"}, # missing 'text'
+            {"id": "good_doc", "text": "Good content", "title": "Good Doc", "url": "/good"}
+        ],
+        "pagination": {"total": 2, "nextPath": None}
+    }
+    with requests_mock.Mocker() as m:
+        m.post("http://outline.test/api/collections.list", json=mock_response_collections_list_single_item)
+        m.post("http://outline.test/api/documents.list", json=bad_document_response)
+        # Mock _build_metadata stuff for the good doc
+        m.post("http://outline.test/api/documents.group_memberships", json={"data": {"groups": []}, "pagination": {"total":0}})
+
+        documents = list(loader.lazy_load())
+
+        assert len(documents) == 1
+        assert documents[0].page_content == "Good content"
+        assert "Error processing document 'Bad Doc'" in caplog.text


### PR DESCRIPTION
# Add `continue_on_failure` and Fix Pagination Logic

## Description
This PR improves the robustness of the `OutlineLoader` by adding a partial success mechanism.
Also, fixes a bug in the pagination logic that could cause infinite loops.

## Key Changes

### 1. New Feature: `continue_on_failure`
- Added a `continue_on_failure` parameter to the `OutlineLoader` constructor.
- When set to `True`, the loader will not raise an exception if:
  - fetching a specific collection fails.
  - fetching group permissions for a document fails.
  - processing a specific document fails.
- Instead, it logs a warning and continues processing the remaining items.
- Default behavior remains `False` (fail fast), preserving backward compatibility.

### 2. Bug Fix: Pagination Infinite Loop
- Fixed a logic error in `_extract_pagination_info`.
- **Previously**: If the API response did not contain a `nextPath` (indicating the last page), the `next_offset` defaulted to `0`. If `total > 0`, the loop condition `offset < total` would remain true indefinitely, causing the loader to re-fetch the first page forever.
- **Now**: `next_offset` defaults to `total` when `nextPath` is missing. This ensures the loop condition `offset < total` evaluates to `False`, correctly terminating the iteration.

## Testing
- Added new tests in `tests/document_loaders/test_outline.py` to verify:
  - `continue_on_failure` handles collection errors.
  - `continue_on_failure` handles group membership errors.
  - `continue_on_failure` handles malformed documents.
- Verified that existing tests pass.
